### PR TITLE
:sparkles: Add llvm variants of default profiles

### DIFF
--- a/profiles/armv8/mac/default-llvm
+++ b/profiles/armv8/mac/default-llvm
@@ -1,0 +1,12 @@
+[settings]
+arch=armv8
+build_type=Debug
+compiler=clang
+compiler.cppstd=20
+compiler.libcxx=libc++
+compiler.version=16
+os=Macos
+
+[buildenv]
+CC=/opt/homebrew/Cellar/llvm/16.0.6/bin/clang
+CXX=/opt/homebrew/Cellar/llvm/16.0.6/bin/clang++

--- a/profiles/x86_64/mac/default-llvm
+++ b/profiles/x86_64/mac/default-llvm
@@ -1,0 +1,12 @@
+[settings]
+arch=x86_64
+build_type=Debug
+compiler=clang
+compiler.cppstd=20
+compiler.libcxx=libc++
+compiler.version=16
+os=Macos
+
+[buildenv]
+CC=/opt/homebrew/Cellar/llvm/16.0.6/bin/clang
+CXX=/opt/homebrew/Cellar/llvm/16.0.6/bin/clang++


### PR DESCRIPTION
These are added for future reference for when they are needed. These will not be used currently.