### PR TITLE
:technologist: Use build_type=Release for all profiles

### DIFF
--- a/profiles/armv8/linux/default
+++ b/profiles/armv8/linux/default
@@ -1,6 +1,6 @@
 [settings]
 arch=armv8
-build_type=Debug
+build_type=Release
 compiler=gcc
 compiler.cppstd=20
 compiler.libcxx=libstdc++11

--- a/profiles/armv8/mac/default
+++ b/profiles/armv8/mac/default
@@ -1,6 +1,6 @@
 [settings]
 arch=armv8
-build_type=Debug
+build_type=Release
 compiler=apple-clang
 compiler.cppstd=20
 compiler.libcxx=libc++

--- a/profiles/armv8/mac/default-llvm
+++ b/profiles/armv8/mac/default-llvm
@@ -1,6 +1,6 @@
 [settings]
 arch=armv8
-build_type=Debug
+build_type=Release
 compiler=clang
 compiler.cppstd=20
 compiler.libcxx=libc++

--- a/profiles/armv8/windows/default
+++ b/profiles/armv8/windows/default
@@ -1,6 +1,6 @@
 [settings]
 arch=armv8
-build_type=Debug
+build_type=Release
 compiler=gcc
 compiler.cppstd=20
 compiler.libcxx=libstdc++11

--- a/profiles/baremetal/settings_user.yml
+++ b/profiles/baremetal/settings_user.yml
@@ -1,13 +1,15 @@
 arch:
-  thumbv6:
-    processor: ["cortex-m0", "cortex-m0plus", "cortex-m1"]
-
-  thumbv7:
-    float_abi: ["soft", "softfp", "hard"]
-    fpu: ["auto", "vfpv4", "fpv4-d16", "fpv4-sp-d16", "fpv5-sp-d16", "fpv5-d16"]
-    processor: ["cortex-m3", "cortex-m4", "cortex-m7"]
-
-  thumbv8:
-    float_abi: ["soft", "softfp", "hard"]
-    processor:
-      ["cortex-m23", "cortex-m33", "cortex-m35p", "cortex-m55", "cortex-m85"]
+  [
+    "cortex-m0",
+    "cortex-m0plus",
+    "cortex-m1",
+    "cortex-m3",
+    "cortex-m4+nofp",
+    "cortex-m4",
+    "cortex-m7",
+    "cortex-m23",
+    "cortex-m33",
+    "cortex-m35p",
+    "cortex-m55",
+    "cortex-m85",
+  ]

--- a/profiles/x86_64/linux/default
+++ b/profiles/x86_64/linux/default
@@ -1,6 +1,6 @@
 [settings]
 arch=x86_64
-build_type=Debug
+build_type=Release
 compiler=gcc
 compiler.cppstd=20
 compiler.libcxx=libstdc++11

--- a/profiles/x86_64/mac/default
+++ b/profiles/x86_64/mac/default
@@ -1,6 +1,6 @@
 [settings]
 arch=x86_64
-build_type=Debug
+build_type=Release
 compiler=apple-clang
 compiler.cppstd=20
 compiler.libcxx=libc++

--- a/profiles/x86_64/mac/default-llvm
+++ b/profiles/x86_64/mac/default-llvm
@@ -1,6 +1,6 @@
 [settings]
 arch=x86_64
-build_type=Debug
+build_type=Release
 compiler=clang
 compiler.cppstd=20
 compiler.libcxx=libc++

--- a/profiles/x86_64/windows/default
+++ b/profiles/x86_64/windows/default
@@ -1,6 +1,6 @@
 [settings]
 arch=x86_64
-build_type=Debug
+build_type=Release
 compiler=gcc
 compiler.cppstd=20
 compiler.libcxx=libstdc++11


### PR DESCRIPTION
The build profile should use the release version of whatever application
it is targeting, rather than the debug version.