### PR TITLE
:wrench: Add settings_user.yml v2

### DIFF
--- a/profiles/baremetal/v2/settings_user.yml
+++ b/profiles/baremetal/v2/settings_user.yml
@@ -1,0 +1,25 @@
+arch:
+  [
+    "cortex-m0",
+    "cortex-m0plus",
+    "cortex-m1",
+    "cortex-m3",
+    "cortex-m4",
+    "cortex-m4f",
+    "cortex-m7",
+    "cortex-m7f",
+    "cortex-m7d",
+    "cortex-m23",
+    "cortex-m33",
+    "cortex-m33f",
+    "cortex-m33p",
+    "cortex-m35pf",
+    "cortex-m55",
+    "cortex-m85",
+  ]
+compiler:
+  gcc:
+    # libc to be linked to the binary with baremetal OS
+    # Must NOT be specified for building libraries
+    # ANY allows additional libc variants
+    libc: [null, nano, nosys, linux, nano_nosys, picolibc, ANY]


### PR DESCRIPTION
The original user settings yml file was far too complex. The creator of conan saw the tree like structure for each architecture and stated that the set of potential options would cause an explosion of binaries, which is correct. This number can be brought down by using the cpu names we commonly use with arm cortex devices.

V2 also adds the libc setting for the GCC compiler, allowing a selection of .specs such as nano, nosys, and importantly picolibc.