### PR TITLE
:truck: rename libc to newlib for GCC

### DIFF
--- a/profiles/baremetal/v2/settings_user.yml
+++ b/profiles/baremetal/v2/settings_user.yml
@@ -22,4 +22,4 @@ compiler:
     # libc to be linked to the binary with baremetal OS
     # Must NOT be specified for building libraries
     # ANY allows additional libc variants
-    libc: [null, nano, nosys, linux, nano_nosys, picolibc, ANY]
+    newlib: [null, nano, nosys, linux, nano_nosys, picolibc, ANY]


### PR DESCRIPTION
Normally this would be a breaking change, but no one is using the current version of arm-gnu-toolchain with split picolibc.