### PR TITLE
:bricks: Remove libc from settings_user.yml

### DIFF
--- a/profiles/baremetal/v2/settings_user.yml
+++ b/profiles/baremetal/v2/settings_user.yml
@@ -17,9 +17,3 @@ arch:
     "cortex-m55",
     "cortex-m85",
   ]
-compiler:
-  gcc:
-    # libc to be linked to the binary with baremetal OS
-    # Must NOT be specified for building libraries
-    # ANY allows additional libc variants
-    newlib: [null, nano, nosys, linux, nano_nosys, picolibc, ANY]


### PR DESCRIPTION
Using newlib as a compatibility setting is incorrect as the choice of newlib libc library implementation is a link time choice and does not affect codegen or ABI.